### PR TITLE
Improved: Hide Basic Heading component from vuestorefront.(CMS-100031)

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/simpletext/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/themecleanflex/components/simpletext/.content.xml
@@ -10,7 +10,7 @@
     <sample-h1 jcr:primaryType="nt:unstructured" title="Basic Heading 1" group=".hidden">
       <jcr:content jcr:primaryType="nt:unstructured" text="Themeclean Heading" element="h1"/>
     </sample-h1>
-    <sample-h2 jcr:primaryType="nt:unstructured" title="Basic Heading" group="Text Components">
+    <sample-h2 jcr:primaryType="nt:unstructured" title="Basic Heading" group=".hidden">
       <jcr:content jcr:primaryType="nt:unstructured" text="Themeclean Secondary Heading" element="h2"/>
     </sample-h2>
   </jcr:content>


### PR DESCRIPTION
1. We hide Basic Heading(Simpletext) component from Vue Storefront because it is tight bounded with vue storefront breadcrumb so this is not working properly on the index page.
2. We will discuss on this topic in the future.



